### PR TITLE
Second Iteraction

### DIFF
--- a/.idea/bite_blueprint.iml
+++ b/.idea/bite_blueprint.iml
@@ -53,6 +53,7 @@
     <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="date (v3.4.1, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="debug (v1.10.0, rbenv: 3.4.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="declarative (v0.0.20, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="dotenv (v3.1.7, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="drb (v2.2.1, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ed25519 (v1.3.0, rbenv: 3.4.2) [gem]" level="application" />
@@ -77,6 +78,7 @@
     <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.5, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.25.5, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.8.0, rbenv: 3.4.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="multi_json (v1.15.0, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.5.6, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.2, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-protocol (v0.2.2, rbenv: 3.4.2) [gem]" level="application" />
@@ -109,6 +111,7 @@
     <orderEntry type="library" scope="PROVIDED" name="rdoc (v6.13.0, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.10.0, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="reline (v0.6.0, rbenv: 3.4.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="representable (v3.2.0, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.75.1, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.43.0, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-performance (v1.24.0, rbenv: 3.4.2) [gem]" level="application" />
@@ -125,7 +128,9 @@
     <orderEntry type="library" scope="PROVIDED" name="thor (v1.3.2, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="thruster (v0.1.12, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="timeout (v0.4.3, rbenv: 3.4.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="trailblazer-option (v0.1.2, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, rbenv: 3.4.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="uber (v0.1.0, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v3.1.4, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="unicode-emoji (v4.0.4, rbenv: 3.4.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="uri (v1.0.3, rbenv: 3.4.2) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,12 @@ gem "thruster", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
+# Project Gems
+
+# Decorators
+gem "representable"
+gem "multi_json"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    declarative (0.0.20)
     dotenv (3.1.7)
     drb (2.2.1)
     ed25519 (1.3.0)
@@ -141,6 +142,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_json (1.15.0)
     net-imap (0.5.6)
       date
       net-protocol
@@ -228,6 +230,10 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
     rubocop (1.75.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -293,8 +299,10 @@ GEM
     thruster (0.1.12-aarch64-linux)
     thruster (0.1.12-x86_64-linux)
     timeout (0.4.3)
+    trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uber (0.1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -323,8 +331,10 @@ DEPENDENCIES
   factory_bot_rails
   faker
   kamal
+  multi_json
   puma (>= 5.0)
   rails (~> 8.0.1)
+  representable
   rubocop-rails-omakase
   solid_cable
   solid_cache

--- a/app/controllers/api/v1/menu_controller.rb
+++ b/app/controllers/api/v1/menu_controller.rb
@@ -5,7 +5,7 @@ module Api
         menus = Menu.includes(:menu_items).all
 
         if menus.any?
-          render json: menus_with_menu_items(menus:), status: :ok
+          render json: MenuRepresenter.for_collection.new(menus), status: :ok
         else
           render json: { error: "No menu found please try again later" }, status: :not_found
         end
@@ -15,40 +15,10 @@ module Api
         menu = Menu.includes(:menu_items).find_by(id: params[:id])
 
         if menu
-          render json: menu_representer(menu:), status: :ok
+          render json: MenuRepresenter.new(menu), status: :ok
         else
           render json: { error: "No menu found please try again later" }, status: :not_found
         end
-      end
-
-      private
-
-      def menus_with_menu_items(menus:)
-        return { menus: } if menus.empty?
-
-        menus.map do |menu|
-          result = menu_representer(menu:)
-
-          result
-        end
-      end
-
-      def menu_representer(menu:)
-        result = menu.attributes.symbolize_keys
-        result[:created_at] = result[:created_at].strftime("%Y-%m-%d")
-        result[:updated_at] = result[:updated_at].strftime("%Y-%m-%d")
-        result[:menu_items] = menu.menu_items.map { |menu_item| menu_item_representer(menu_item:) }
-
-        result
-      end
-
-      def menu_item_representer(menu_item:)
-        result = menu_item.attributes.symbolize_keys
-        result[:created_at] = result[:created_at].strftime("%Y-%m-%d")
-        result[:updated_at] = result[:updated_at].strftime("%Y-%m-%d")
-        result[:price] = result[:price] / 100.0
-
-        result.except(:menu_id)
       end
     end
   end

--- a/app/controllers/api/v1/restaurant_controller.rb
+++ b/app/controllers/api/v1/restaurant_controller.rb
@@ -1,21 +1,25 @@
-class Api::V1::RestaurantController < ApplicationController
-  def index
-    restaurants = Restaurant.all
+module Api
+  module V1
+    class RestaurantController < ApplicationController
+      def index
+        restaurants = Restaurant.includes(menus: :menu_items).all
 
-    if restaurants.any?
-      render json: restaurants, status: 200
-    else
-      render json: { error: "No menu found please try again later" }, status: :not_found
-    end
-  end
+        if restaurants.any?
+          render json: RestaurantRepresenter.for_collection.new(restaurants), status: 200
+        else
+          render json: { error: "No menu found please try again later" }, status: :not_found
+        end
+      end
 
-  def show
-    restaurant = Restaurant.find_by(id: params[:id])
+      def show
+        restaurant = Restaurant.find_by(id: params[:id])
 
-    if restaurant
-      render json: restaurant, status: 200
-    else
-      render json: { error: "No menu found please try again later" }, status: :not_found
+        if restaurant
+          render json: RestaurantRepresenter.new(restaurant), status: 200
+        else
+          render json: { error: "No menu found please try again later" }, status: :not_found
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/v1/restaurant_controller.rb
+++ b/app/controllers/api/v1/restaurant_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::RestaurantController < ApplicationController
+  def index
+    restaurants = Restaurant.all
+
+    if restaurants.any?
+      render json: restaurants, status: 200
+    else
+      render json: { error: "No menu found please try again later" }, status: :not_found
+    end
+  end
+
+  def show
+    restaurant = Restaurant.find_by(id: params[:id])
+
+    if restaurant
+      render json: restaurant, status: 200
+    else
+      render json: { error: "No menu found please try again later" }, status: :not_found
+    end
+  end
+end

--- a/app/decorators/menu_item_representer.rb
+++ b/app/decorators/menu_item_representer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class MenuItemRepresenter < Representable::Decorator
+  include Representable::JSON
+
+  property :id
+  property :name
+  property :description
+  property :price, exec_context: :decorator
+  property :created_at, exec_context: :decorator
+  property :updated_at, exec_context: :decorator
+
+  def price
+    represented.price / 100.0
+  end
+
+  def created_at
+    represented.created_at.strftime("%Y-%m-%d")
+  end
+
+  def updated_at
+    represented.updated_at.strftime("%Y-%m-%d")
+  end
+end

--- a/app/decorators/menu_representer.rb
+++ b/app/decorators/menu_representer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MenuRepresenter < Representable::Decorator
+  include Representable::JSON
+
+  property :id
+  property :name
+  property :description
+  property :restaurant_id
+  property :created_at, exec_context: :decorator
+  property :updated_at, exec_context: :decorator
+  collection :menu_items, decorator: MenuItemRepresenter
+
+  def created_at
+    represented.created_at.strftime("%Y-%m-%d")
+  end
+
+  def updated_at
+    represented.updated_at.strftime("%Y-%m-%d")
+  end
+end

--- a/app/decorators/restaurant_representer.rb
+++ b/app/decorators/restaurant_representer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RestaurantRepresenter < Representable::Decorator
+  include Representable::JSON
+
+  property :id
+  property :name
+  property :description
+  property :category
+  collection :menus, decorator: MenuRepresenter
+  property :created_at, exec_context: :decorator
+  property :updated_at, exec_context: :decorator
+
+  def created_at
+    represented.created_at.strftime("%Y-%m-%d")
+  end
+
+  def updated_at
+    represented.updated_at.strftime("%Y-%m-%d")
+  end
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,3 +1,3 @@
 class Menu < ApplicationRecord
-  has_many :menu_items
+  belongs_to :restaurant
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,3 +1,5 @@
 class Menu < ApplicationRecord
   belongs_to :restaurant
+
+  has_and_belongs_to_many :menu_items
 end

--- a/app/models/menu_item.rb
+++ b/app/models/menu_item.rb
@@ -1,3 +1,3 @@
 class MenuItem < ApplicationRecord
-  belongs_to :menu
+  has_and_belongs_to_many :menus
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,0 +1,2 @@
+class Restaurant < ApplicationRecord
+end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,2 +1,3 @@
 class Restaurant < ApplicationRecord
+  has_many :menus
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,3 +1,4 @@
 class Restaurant < ApplicationRecord
   has_many :menus
+  has_many :menu_items, through: :menus
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :menu, only: [ :index, :show ]
+      resources :restaurant, only: %i[index show]
+      resources :menu, only:  %i[index show]
     end
   end
 end

--- a/db/migrate/20250329172709_create_restaurants.rb
+++ b/db/migrate/20250329172709_create_restaurants.rb
@@ -1,0 +1,11 @@
+class CreateRestaurants < ActiveRecord::Migration[8.0]
+  def change
+    create_table :restaurants do |t|
+      t.string :name
+      t.text :description
+      t.string :category
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250329172754_remove_menu_item_belongs_to.rb
+++ b/db/migrate/20250329172754_remove_menu_item_belongs_to.rb
@@ -1,0 +1,5 @@
+class RemoveMenuItemBelongsTo < ActiveRecord::Migration[8.0]
+  def change
+    remove_belongs_to :menu_items, :menu
+  end
+end

--- a/db/migrate/20250329175034_add_restaurant_to_menus.rb
+++ b/db/migrate/20250329175034_add_restaurant_to_menus.rb
@@ -1,0 +1,5 @@
+class AddRestaurantToMenus < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :menus, :restaurant, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250329175523_create_join_table_menu_menu_item.rb
+++ b/db/migrate/20250329175523_create_join_table_menu_menu_item.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableMenuMenuItem < ActiveRecord::Migration[8.0]
+  def change
+    create_join_table :menus, :menu_items do |t|
+      t.index [ :menu_id, :menu_item_id ]
+      t.index [ :menu_item_id, :menu_id ]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_28_213057) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_172754) do
   create_table "menu_items", force: :cascade do |t|
     t.string "name"
     t.text "description"
     t.integer "price"
-    t.integer "menu_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["menu_id"], name: "index_menu_items_on_menu_id"
     t.index ["name"], name: "index_menu_items_on_name", unique: true
   end
 
@@ -30,5 +28,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_28_213057) do
     t.index ["name"], name: "index_menus_on_name", unique: true
   end
 
-  add_foreign_key "menu_items", "menus"
+  create_table "restaurants", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.string "category"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_172754) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_175034) do
   create_table "menu_items", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -25,7 +25,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_172754) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "restaurant_id", null: false
     t.index ["name"], name: "index_menus_on_name", unique: true
+    t.index ["restaurant_id"], name: "index_menus_on_restaurant_id"
   end
 
   create_table "restaurants", force: :cascade do |t|
@@ -35,4 +37,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_172754) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_foreign_key "menus", "restaurants"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_29_175034) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_29_175523) do
   create_table "menu_items", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -18,6 +18,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_29_175034) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_menu_items_on_name", unique: true
+  end
+
+  create_table "menu_items_menus", id: false, force: :cascade do |t|
+    t.integer "menu_id", null: false
+    t.integer "menu_item_id", null: false
+    t.index ["menu_id", "menu_item_id"], name: "index_menu_items_menus_on_menu_id_and_menu_item_id"
+    t.index ["menu_item_id", "menu_id"], name: "index_menu_items_menus_on_menu_item_id_and_menu_id"
   end
 
   create_table "menus", force: :cascade do |t|

--- a/test/controllers/api/v1/menu_controller_test.rb
+++ b/test/controllers/api/v1/menu_controller_test.rb
@@ -1,40 +1,44 @@
 require "test_helper"
 
-class Api::V1::MenuControllerTest < ActionDispatch::IntegrationTest
-  test "Should return a list of Menus" do
-    create_list(:menu, 5)
+module Api
+  module V1
+    class MenuControllerTest < ActionDispatch::IntegrationTest
+      test "Should return a list of Menus" do
+        create_list(:menu, 5)
 
-    get api_v1_menu_index_url
-    body = JSON.parse(@response.body)
+        get api_v1_menu_index_url
+        body = JSON.parse(@response.body, symbolize_names: true)
 
-    assert body.size == 5
-    assert body.first["menu_items"].present?
-    assert_response :success
-  end
+        assert body.size == 5
+        assert body.first[:menu_items].present?
+        assert_response :success
+      end
 
-  test "Should return 404 if no Menu is found" do
-    get api_v1_menu_index_url
-    body = JSON.parse(@response.body)
+      test "Should return 404 if no Menu is found" do
+        get api_v1_menu_index_url
+        body = JSON.parse(@response.body, symbolize_names: true)
 
-    assert body["error"].present?
-    assert_response :not_found
-  end
+        assert body[:error].present?
+        assert_response :not_found
+      end
 
-  test "Should get show" do
-    menu = create(:menu)
+      test "Should return a specific menu" do
+        menu = create(:menu)
 
-    get api_v1_menu_url(menu.id)
-    body = JSON.parse(@response.body)
+        get api_v1_menu_url(menu.id)
+        body = JSON.parse(@response.body, symbolize_names: true)
 
-    assert body.first["menu_items"].present?
-    assert_response :success
-  end
+        assert body[:menu_items].present?
+        assert_response :success
+      end
 
-  test "Should return 404 if not Menu is found" do
-    get api_v1_menu_url(1)
-    body = JSON.parse(@response.body)
+      test "Should return 404 if not Menu is found" do
+        get api_v1_menu_url(1)
+        body = JSON.parse(@response.body, symbolize_names: true)
 
-    assert body["error"].present?
-    assert_response :not_found
+        assert body[:error].present?
+        assert_response :not_found
+      end
+    end
   end
 end

--- a/test/controllers/api/v1/restaurant_controller_test.rb
+++ b/test/controllers/api/v1/restaurant_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Api::V1::RestaurantControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_v1_restaurant_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get api_v1_restaurant_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/api/v1/restaurant_controller_test.rb
+++ b/test/controllers/api/v1/restaurant_controller_test.rb
@@ -1,13 +1,28 @@
 require "test_helper"
 
-class Api::V1::RestaurantControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get api_v1_restaurant_index_url
-    assert_response :success
-  end
+module Api
+  module V1
+    class RestaurantControllerTest < ActionDispatch::IntegrationTest
+      test "Should return a list of restaurants" do
+        create_list(:restaurant, 5)
 
-  test "should get show" do
-    get api_v1_restaurant_show_url
-    assert_response :success
+        get api_v1_restaurant_index_url
+        body = JSON.parse(@response.body, symbolize_names: true)
+
+        assert body.size == 5
+        assert body.first[:name] == Restaurant.first.name
+        assert_response :success
+      end
+
+      test "Should return a specific restaurant" do
+        create(:restaurant)
+
+        get  api_v1_restaurant_url(1)
+        body = JSON.parse(@response.body, symbolize_names: true)
+
+        assert body[:name] == Restaurant.first.name
+        assert_response :success
+      end
+    end
   end
 end

--- a/test/factories/menu_factory.rb
+++ b/test/factories/menu_factory.rb
@@ -4,7 +4,8 @@ FactoryBot.define do
   factory :menu do
     name { "#{Faker::Restaurant.name} - #{Faker::Food.ethnic_category}" }
     description  { Faker::Food.description }
+    association :restaurant, factory: :restaurant
 
-    after(:create) { |menu| FactoryBot.create_list(:menu_item, 5, menu: menu) }
+    after(:create) { |menu| FactoryBot.create_list(:menu_item, 5, menus: [ menu ]) }
   end
 end

--- a/test/factories/menu_item_factory.rb
+++ b/test/factories/menu_item_factory.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     name { Faker::Food.unique.dish  }
     description  { Faker::Food.description }
     price { Faker::Number.number(digits: 4) }
-    association :menu, factory: :menu
   end
 end

--- a/test/factories/restaurants.rb
+++ b/test/factories/restaurants.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :restaurant do
+    name { Faker::Restaurant.unique.name }
+    description { Faker::Restaurant.description }
+    category { Faker::Restaurant.type }
+  end
+end

--- a/test/models/menu_item_test.rb
+++ b/test/models/menu_item_test.rb
@@ -10,15 +10,9 @@ class MenuItemTest < ActiveSupport::TestCase
     end
   end
 
-  test "Cannot create a MenuItem without a Menu" do
-    menu_item = build(:menu_item, menu: nil)
-
-    assert_not menu_item.save
-  end
-
-  test "A MenuItem belongs to a Menu" do
+  test "A MenuItem has many Menus" do
     menu_item = create(:menu_item)
 
-    assert menu_item.menu
+    assert menu_item.menus
   end
 end

--- a/test/models/restaurant_test.rb
+++ b/test/models/restaurant_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RestaurantTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Introduce Restaurant model with Menu relationships

This PR implements the Restaurant model and establishes many-to-many relationships between Restaurants, Menus, and MenuItems. Key changes include:

### New Features
- Added Restaurant model with index/show endpoints
- Implemented decorators for Restaurant, Menu, and MenuItem
- Added test coverage for Restaurant endpoints

### Model Changes
- Updated Menu<->MenuItem relationship from `has_many/belongs_to` to `has_and_belongs_to_many`
- Updated factories to support the new relationship

### Refactoring
- Moved formatting logic from controllers to decorators
- Updated test suites for Menu and MenuItem

### The changes enable:
- A restaurant to have many menus
- MenuItems to belong to multiple menus within the same restaurant